### PR TITLE
Fix iOS Safari reload detection (issue #3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 # misc
 .DS_Store
 *.pem
+/.work/
 
 # debug
 npm-debug.log*

--- a/actions/revalidate.ts
+++ b/actions/revalidate.ts
@@ -1,0 +1,13 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+export async function revalidateCurrentPath(pathname: string) {
+  try {
+    revalidatePath(pathname);
+    return { success: true };
+  } catch (error) {
+    console.error("Failed to revalidate path:", error);
+    return { success: false, error: String(error) };
+  }
+}

--- a/app/[locale]/folders/[folderId]/page.tsx
+++ b/app/[locale]/folders/[folderId]/page.tsx
@@ -6,7 +6,7 @@ import { findFolderById, findParentFolder } from "@/utils/folder";
 import { notFound } from "next/navigation";
 import { Metadata } from "next";
 import { settingsService } from "@/lib/settings";
-import { cacheControlWithHeaders } from "@/utils/fetch";
+import { getFetchOptions } from "@/utils/fetch";
 
 interface FolderPageProps {
   params: Promise<{ folderId: string }>;
@@ -15,7 +15,7 @@ interface FolderPageProps {
 export default async function Page({ params }: FolderPageProps) {
   const { folderId } = await params;
 
-  const fetchOptions = await cacheControlWithHeaders();
+  const fetchOptions = await getFetchOptions();
 
   const [folders, items, libraryPath, layout, folderOrder] = await Promise.all([
     fetchFolders({ fetchOptions }),
@@ -48,7 +48,7 @@ export async function generateMetadata({
   params,
 }: FolderPageProps): Promise<Metadata> {
   const { folderId } = await params;
-  const fetchOptions = await cacheControlWithHeaders();
+  const fetchOptions = await getFetchOptions();
   const folders = await fetchFolders({ fetchOptions });
   const folder = findFolderById(folders, folderId);
   if (!folder) {

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { NextIntlClientProvider, hasLocale } from "next-intl";
 import { notFound } from "next/navigation";
 import { routing } from "@/i18n/routing";
+import { ReloadDetector } from "@/components/ReloadDetector";
 import "@/styles/globals.css";
 
 export const metadata: Metadata = {
@@ -24,7 +25,10 @@ export default async function RootLayout({
   return (
     <html lang={locale}>
       <body>
-        <NextIntlClientProvider>{children}</NextIntlClientProvider>
+        <NextIntlClientProvider>
+          <ReloadDetector />
+          {children}
+        </NextIntlClientProvider>
       </body>
     </html>
   );

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -2,10 +2,10 @@ import { HomePage } from "@/components/HomePage/HomePage";
 import { fetchFolders } from "@/lib/api/folder";
 import { fetchLibraryPath } from "@/lib/api/library";
 import { settingsService } from "@/lib/settings";
-import { cacheControlWithHeaders } from "@/utils/fetch";
+import { getFetchOptions } from "@/utils/fetch";
 
 export default async function Home() {
-  const fetchOptions = await cacheControlWithHeaders();
+  const fetchOptions = await getFetchOptions();
 
   const [folders, libraryPath, layout, folderOrder] = await Promise.all([
     fetchFolders({ fetchOptions }),

--- a/components/FolderPage/FolderPage.tsx
+++ b/components/FolderPage/FolderPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState, useTransition } from "react";
+import { useMemo, useState, useTransition, useEffect } from "react";
 import {
   ITEM_ORDER_BY,
   FOLDER_ORDER_BY,
@@ -44,6 +44,14 @@ export function FolderPage({
     useState<Order<FolderOrderBy>>(initialFolderOrder);
   const [layout, setLayout] = useState<Layout>(initialLayout);
   const [, startTransition] = useTransition();
+
+  // Sync itemOrder with folder props when they change (after refresh)
+  useEffect(() => {
+    setItemOrder({
+      orderBy: folder.orderBy,
+      sortIncrease: folder.sortIncrease,
+    });
+  }, [folder.orderBy, folder.sortIncrease]);
 
   // Determine if we should use folder ordering (no items but has children)
   const useFolderOrdering = items.length === 0 && folder.children.length > 0;

--- a/components/ReloadDetector.tsx
+++ b/components/ReloadDetector.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect, startTransition, useRef } from "react";
+import { usePathname } from "next/navigation";
+import { revalidateCurrentPath } from "@/actions/revalidate";
+
+export function ReloadDetector() {
+  const pathname = usePathname();
+  const hasCheckedReload = useRef(false);
+
+  useEffect(() => {
+    // Only check once per app lifecycle
+    if (hasCheckedReload.current) return;
+
+    const navigationEntries = window.performance.getEntriesByType(
+      "navigation"
+    ) as PerformanceNavigationTiming[];
+
+    if (navigationEntries[0]?.type === "reload") {
+      hasCheckedReload.current = true;
+      startTransition(() => {
+        revalidateCurrentPath(pathname).then((result) => {
+          if (!result.success) {
+            console.error("Failed to revalidate on reload:", result.error);
+          }
+        });
+      });
+    }
+  }, [pathname]);
+
+  return null;
+}

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -10,7 +10,7 @@ import {
   type FolderOrderBy,
   FOLDER_ORDER_BY,
 } from "@/types/models";
-import { revalidatePath, revalidateTag, unstable_cache } from "next/cache";
+import { revalidateTag, unstable_cache } from "next/cache";
 
 const SETTINGS_CACHE_TAG = "settings";
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naamiru/eagle-webui",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A mobile-friendly web interface for Eagle image viewer - browse your Eagle library from any device",
   "keywords": [
     "eagle",
@@ -36,7 +36,7 @@
     "dev": "next dev --turbopack",
     "lint": "next lint",
     "build": "next build && cp -r .next/static .next/standalone/.next/",
-    "start": "next start",
+    "start": "node start.js --hostname 0.0.0.0 --port 3000",
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {

--- a/utils/fetch.ts
+++ b/utils/fetch.ts
@@ -1,17 +1,7 @@
 import "server-only";
 
-import { headers } from "next/headers";
 import { EAGLE_API_CACHE_TTL } from "@/env";
 
-export async function cacheControlWithHeaders(): Promise<RequestInit> {
-  const headerList = await headers();
-  const cacheControl = headerList.get("cache-control");
-  const shouldRevalidate =
-    cacheControl?.includes("max-age=0") ||
-    cacheControl?.includes("no-cache") ||
-    cacheControl?.includes("no-store");
-
-  return shouldRevalidate
-    ? { cache: "no-cache" }
-    : { next: { revalidate: EAGLE_API_CACHE_TTL } };
+export async function getFetchOptions(): Promise<RequestInit> {
+  return { next: { revalidate: EAGLE_API_CACHE_TTL } };
 }


### PR DESCRIPTION
Fixes #3

- Replace header-based cache detection with client-side reload detection
- Use PerformanceNavigationTiming API to detect page reloads
- Add ReloadDetector component that triggers revalidation on reload
- Rename cacheControlWithHeaders to getFetchOptions (headers no longer used)
- Fix itemOrder state sync in FolderPage when props change
- Add startTransition for smooth revalidation handling

This resolves the issue where iOS Safari doesn't send Cache-Control headers on reload, preventing Eagle API data from refreshing properly.